### PR TITLE
Remove auto-install, fix directories, fix failing task on success

### DIFF
--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ -f yarn.lock ]; then
-    yarn --non-interactive --silent --ignore-scripts --production=false --frozen-lockfile
+    yarn --non-interactive --silent --ignore-scripts --production=false --frozen-lockfile --prefer-offline
 else
     NODE_ENV=development npm install
 fi

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,6 +2,10 @@
 
 set -e
 
-npm install
+if [ -f yarn.lock ]; then
+    yarn --non-interactive --silent --ignore-scripts --production=false
+else
+    NODE_ENV=development npm install
+fi
 
 NODE_PATH=node_modules node /action/lib/run.js

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ -f yarn.lock ]; then
-    yarn --non-interactive --silent --ignore-scripts --production=false
+    yarn --non-interactive --silent --ignore-scripts --production=false --frozen-lockfile
 else
     NODE_ENV=development npm install
 fi

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,10 +2,4 @@
 
 set -e
 
-if [ -f yarn.lock ]; then
-    yarn --non-interactive --silent --ignore-scripts --production=false --frozen-lockfile --prefer-offline
-else
-    NODE_ENV=development npm install
-fi
-
 NODE_PATH=node_modules node /action/lib/run.js

--- a/lib/run.js
+++ b/lib/run.js
@@ -37,10 +37,8 @@ async function createCheck() {
 function eslint() {
   const eslint = require('eslint')
 
-  const cli = new eslint.CLIEngine({
-    extensions: [".js", ".ts", ".vue"]
-  })
-  const report = cli.executeOnFiles(['app'])
+  const cli = new eslint.CLIEngine()
+  const report = cli.executeOnFiles(['.'])
   // fixableErrorCount, fixableWarningCount are available too
   const { results, errorCount, warningCount } = report
 
@@ -64,7 +62,10 @@ function eslint() {
   }
 
   return {
-    conclusion: errorCount > 0 ? 'failure' : 'success',
+    // This task may succeed or not, but the annotations sent to the API determine if there was a failure. If eslint ran
+    // successfully, this should be a success.
+    conclusion: 'success',
+    // conclusion: errorCount > 0 ? 'failure' : 'success',
     output: {
       title: checkName,
       summary: `${errorCount} error(s), ${warningCount} warning(s) found`,

--- a/lib/run.js
+++ b/lib/run.js
@@ -62,10 +62,7 @@ function eslint() {
   }
 
   return {
-    // This task may succeed or not, but the annotations sent to the API determine if there was a failure. If eslint ran
-    // successfully, this should be a success.
-    conclusion: 'success',
-    // conclusion: errorCount > 0 ? 'failure' : 'success',
+    conclusion: errorCount > 0 ? 'failure' : 'success',
     output: {
       title: checkName,
       summary: `${errorCount} error(s), ${warningCount} warning(s) found`,
@@ -106,7 +103,7 @@ async function run() {
     console.log(output.summary)
     await updateCheck(id, conclusion, output)
     if (conclusion === 'failure') {
-      process.exit(78)
+      console.error("eslint ran successfully but found errors.")
     }
   } catch (err) {
     await updateCheck(id, 'failure')

--- a/lib/run.js
+++ b/lib/run.js
@@ -37,8 +37,10 @@ async function createCheck() {
 function eslint() {
   const eslint = require('eslint')
 
-  const cli = new eslint.CLIEngine()
-  const report = cli.executeOnFiles(['.'])
+  const cli = new eslint.CLIEngine({
+    extensions: [".js", ".ts", ".vue"]
+  })
+  const report = cli.executeOnFiles(['app'])
   // fixableErrorCount, fixableWarningCount are available too
   const { results, errorCount, warningCount } = report
 


### PR DESCRIPTION
- Fix: Removes the `npm install` from the entry script, jobs should handle this themselves
- Fix: the eslint task now prints an error if it failed, but if the process itself succeeds it returns successfully. Previously, the process job itself was failing if there were errors, which is wrong.
- Hack: force `.js, .ts, .vue` and the `app` folder for our own app.